### PR TITLE
[feat] #9 git commit 로직 구현

### DIFF
--- a/src/main/java/com/github/filemanager/FileManager.java
+++ b/src/main/java/com/github/filemanager/FileManager.java
@@ -645,6 +645,11 @@ public class FileManager {
         gui.repaint();
     }
 
+    /**
+     * 5/3 Bug Report
+     * 밑의 isInGitRepository() 함수를 사용하는 경우 단일 파일 선택 후 버튼 클릭 시 (git init, git add 등), 오류가 발생하는 것 같아 대체가 필요해보입니다.
+     */
+
     private boolean isInGitRepository() { // 현재 directory가 git repository인지 판정하는 함수, 이 조건을 충족한 뒤 git 명령어를 실행해야 한다.
         if (currentFile == null) {
             showErrorMessage("No location selected for new file.", "Select Location");
@@ -697,6 +702,12 @@ public class FileManager {
     /**
      * 위의 isInGitRepostiroy()의 경우 단일 파일 선택 시 NullPointerException이 발생하므로 git status 명령어 실행을 통한
      * .git 존재 여부를 판단하는 새로운 isFileInGitRepository() 함수 선언
+     */
+
+
+     /** 5/3 Bug Report
+     * 밑의 isFileInGitRepository() 함수로 대체하면 예외처리 발생을 막는 것 같습니다.
+     * 후의 기능 git rm, git rm --cached 등의 기능에서도 아래의 함수를 사용하면 될 듯 싶음.
      */
 
     private boolean isFileInGitRepository(){
@@ -800,6 +811,8 @@ public class FileManager {
         if (isFileInGitRepository()){ //.git이 존재할 경우
             if (gitCommitPanel == null) {
                 try{
+                    /*-------------------------------커밋 창 UI 구성--------------------------------- */
+
                     String[] columns = {"File", "File Status"};
                     Object[][] data = getStagedFile(currentFile.getParentFile()); //stage된 데이터 오브젝트
                     commitTable = new JTable(data, columns);
@@ -823,6 +836,7 @@ public class FileManager {
                    // 커밋 창 확인 취소 버튼을 "커밋", "취소" 버튼으로 커스터 마이징
                     Object[] choices = {"커밋", "취소"};
                     Object defaultChoice = choices[0];
+                /*---------------------------------------------------------------------------*/
 
                     if (data.length == 0){ //Stage된 파일이 없을 경우 커밋 창 띄우지 말아야 함
                         showErrorMessage("Stage된 파일이 없습니다.", "No Staged File");
@@ -831,6 +845,7 @@ public class FileManager {
                     //커밋 창 띄우기
                     int optionPane = JOptionPane.showOptionDialog(gui, panel, "Git Commit", JOptionPane.OK_CANCEL_OPTION,JOptionPane.QUESTION_MESSAGE,null,choices,defaultChoice);
 
+                    //git commit -m 명령어 실행
                     if (optionPane == JOptionPane.OK_OPTION){ //커밋 버튼을 눌렀을 경우
                         if (textField.getText().isEmpty()){ //커밋 메시지를 입력하지 않았을 경우 에러 메시지 출력
                             showErrorMessage("커밋 메시지를 입력해주세요.","Empty commit message");

--- a/src/main/java/com/github/filemanager/FileManager.java
+++ b/src/main/java/com/github/filemanager/FileManager.java
@@ -23,14 +23,7 @@ SOFTWARE.
  */
 package com.github.filemanager;
 
-import java.awt.BorderLayout;
-import java.awt.Component;
-import java.awt.Container;
-import java.awt.Desktop;
-import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.GridLayout;
-import java.awt.Image;
+import java.awt.*;
 import java.awt.event.*;
 import java.awt.image.*;
 import java.io.*;
@@ -39,6 +32,7 @@ import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import javax.imageio.ImageIO;
 import javax.swing.*;
 import javax.swing.border.*;
@@ -48,6 +42,11 @@ import javax.swing.table.*;
 import javax.swing.tree.*;
 
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 
 /**
  * A basic File Manager. Requires 1.6+ for the Desktop &amp; SwingWorker classes, amongst other
@@ -158,6 +157,10 @@ public class FileManager {
     private JPanel newFilePanel;
     private JRadioButton newTypeFile;
     private JTextField name;
+
+    /* git commit을 눌렀을 때 나오는 새 창을 위한 GUI options/containers */
+    private JPanel gitCommitPanel;
+    private JTextField gitCommitMessage;
 
     public Container getGui() {
         if (gui == null) {
@@ -386,7 +389,7 @@ public class FileManager {
             gitCommitFile.setMnemonic('C');
             gitCommitFile.addActionListener(new ActionListener() {
                 public void actionPerformed(ActionEvent ae) {
-                    // 여기에다가 commit 로직 추가
+                    gitCommitFile();
                 }
             });
             toolBar.add(gitCommitFile);
@@ -759,6 +762,45 @@ public class FileManager {
         }
     }
 
+
+
+
+    private void gitCommitFile() { //git commit 로직
+        JTextField textField;
+        JTable commitTable;
+        JLabel commitLabel;
+        JScrollPane commitScrollPane;
+
+
+
+        if (gitCommitPanel == null) {
+            String[] columns = {"Icon", "File", "Path/name"};
+            Object[][] data = {{"1", "2", "3"}, {"4", "5", "6"}, {"7", "8", "9"}};
+            commitTable = new JTable(data, columns);
+
+            // JTextField 생성
+            JPanel commitPanel = new JPanel(new BorderLayout());
+            commitLabel = new JLabel("Commit Message:");
+            textField = new JTextField(3);
+            commitPanel.add(commitLabel,BorderLayout.NORTH);
+            commitPanel.add(textField, BorderLayout.SOUTH);
+
+
+            commitScrollPane = new JScrollPane(commitTable);
+            commitScrollPane.setPreferredSize(new Dimension(700,200));
+
+
+            // 팝업 대화상자에 JTable, JTextField, JButton 배치
+            JPanel panel = new JPanel(new BorderLayout());
+            panel.add(commitScrollPane, BorderLayout.NORTH);
+            panel.add(commitPanel, BorderLayout.CENTER);
+
+            // JOptionPane.showConfirmDialog()를 사용하여 팝업 대화상자 생성
+            Object[] choices = {"취소", "커밋"};
+            Object defaultChoice = choices[1];
+            int optionPane = JOptionPane.showOptionDialog(gui, panel, "Git Commit", JOptionPane.OK_CANCEL_OPTION,JOptionPane.QUESTION_MESSAGE,null,choices,defaultChoice);
+        }
+    }
 
     private void showErrorMessage(String errorMessage, String errorTitle) {
         JOptionPane.showMessageDialog(gui, errorMessage, errorTitle, JOptionPane.ERROR_MESSAGE);


### PR DESCRIPTION
## 기능 구현 사항 (정상 작동 확인)
- git commit 버튼 클릭 시 커밋 창 출력
- 커밋 창은 Staged된 파일을 출력하는 Table과, Commit Message를 작성하는 Textfield로 구성
- 커밋 메시지를 입력하고 커밋 버튼을 누르면 git commit 명령어 실행
- 성공 시 commit 확인 창 출력

## 기타 구현 사항
- 현재 파일이 있는 경로를 기준으로 staged 된 파일을 모두 불러오기 위한 getStagedFile() 함수 추가적으로 선언

## Todo
- 파일 탐색기로 파일을 지울 경우, 변경사항이 자동으로 stage되어야 함.
- 지운 파일은 status를 deleted로 표시해야 함.
- 파일 상태에 따른 텍스트 색상 변경
