### PR TITLE
[fix] #14 파일 미선택 경고 수정

### DIFF
--- a/src/main/java/com/github/filemanager/FileManager.java
+++ b/src/main/java/com/github/filemanager/FileManager.java
@@ -162,6 +162,9 @@ public class FileManager {
     private JPanel gitCommitPanel;
     private JTextField gitCommitMessage;
 
+    /* List에서 File을 선택했는지 Tree에서 File을 선택헀는지 분간하기 위한 변수. True일 경우에만 git 버튼이 활성화된다.*/
+    private boolean isFileSelectedInList = false;
+
     public Container getGui() {
         if (gui == null) {
             gui = new JPanel(new BorderLayout(3, 3));
@@ -183,6 +186,7 @@ public class FileManager {
                 public void valueChanged(ListSelectionEvent lse) {
                     int row = table.getSelectionModel().getLeadSelectionIndex();
                     setFileDetails(((FileTableModel) table.getModel()).getFile(row));
+                    isFileSelectedInList = true; //리스트에서 파일을 선택했으므로 true
                 }
             };
             table.getSelectionModel().addListSelectionListener(listSelectionListener);
@@ -200,6 +204,7 @@ public class FileManager {
                     DefaultMutableTreeNode node = (DefaultMutableTreeNode) tse.getPath().getLastPathComponent();
                     showChildren(node);
                     setFileDetails((File) node.getUserObject());
+                    isFileSelectedInList = false; //리스트가 아닌 트리에서 파일을 선택했으므로 false. 이때는 git 버튼이 비활성화된다.
                 }
             };
 
@@ -732,8 +737,8 @@ public class FileManager {
     }
 
     private void gitAddFile() { //선택한 파일을 stage하는 git add로직. "git add" 버튼을 누르면 이 로직이 실행된다.
-        if (currentFile == null) {
-            showErrorMessage("No location selected for new file.", "Select Location");
+        if (currentFile == null || !isFileSelectedInList) {
+            showErrorMessage("파일을 선택해주세요.", "Select File");
             return;
         }
 
@@ -803,8 +808,8 @@ public class FileManager {
         JLabel commitLabel;
         JScrollPane commitScrollPane;
 
-        if (currentFile == null) { //선택한 파일이 없으면 에러 메시지
-            showErrorMessage("선택한 파일이 없어 경로를 읽지 못했습니다.", "Select File");
+        if (currentFile == null || !isFileSelectedInList) { //선택한 파일이 없으면 에러 메시지. List가 아닌 Tree에서 파일을 선택했을 경우도 포함
+            showErrorMessage("파일을 선택해주세요.", "Select File");
             return;
         }
 


### PR DESCRIPTION
## 버그 내용
- 파일을 선택하지 않아도 "선택된 파일이 git Repository에 없습니다" 라는 경고 출력

## 주요 변경 사항 (정상 작동 확인)
- 왼쪽 목록은 트리를 표시하고, 오른쪽 목록은 파일 목록을 표시하므로, 오른쪽 목록에서 파일이 선택되어야 함.
- 왼쪽 목록은 Tree, 오른쪽 목록은 List
- 'boolean isFileSelectedInList' 를 통해 리스트에서 파일이 선택되었는지 판별
- selectionListener에서 Tree에서 선택되면 false, List에서 선택되면 true로 바뀌도록 함.
- git 버튼 클릭 시, 조건문에서 'isFileSelectedInList' 값을 확인하도록 수정.
